### PR TITLE
👷 Deploy to Vercel from Github Actions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - run: which vercel
-
       - name: Install Vercel CLI
         run: yarn global add vercel@latest
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Vercel CLI
-        run: yarn global add vercel@latest
-
       # Build project on Vercel
       # vercel CLI is already installed in Github-hosted runners
       - name: Deploy to Vercel

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,7 +7,6 @@ env:
 on:
   push:
     branches-ignore:
-      - main
       - vercel-release
 
 jobs:
@@ -24,5 +23,7 @@ jobs:
       - name: Install Vercel CLI
         run: yarn global add vercel@latest
 
-      - name: Deploy Project Artifacts to Vercel
+      # Build project on Vercel
+      # vercel CLI is already installed in Github-hosted runners
+      - name: Deploy to Vercel
         run: vercel deploy --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - run: which vercel
+
       - name: Install Vercel CLI
         run: yarn global add vercel@latest
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,28 @@
+name: Vercel Preview Deployment
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - vercel-release
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Vercel CLI
+        run: yarn global add vercel@latest
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,8 +20,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Vercel CLI
-        run: yarn global add vercel@latest
-
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,27 @@
+name: Vercel Production Deployment
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  push:
+    branches:
+      - vercel-release
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Vercel CLI
+        run: yarn global add vercel@latest
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,5 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Deploy Project Artifacts to Vercel
+      # Build project on Vercel
+      # vercel CLI is already installed in Github-hosted runners
+      - name: Deploy to Vercel
         run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [master, vercel-release]
-
+on: workflow_call
 
 jobs:
   install:
@@ -12,16 +9,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Install
         uses: ./.github/actions/install
+
   unit-tests:
     runs-on: ubuntu-latest
     needs: install
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Install
         uses: ./.github/actions/install
+
       - name: Run Unit Tests
         run: yarn test:unit
 


### PR DESCRIPTION
Added 2 new Github Actions workflow: `deploy-preview` and `deploy-prod`.
Both workflows will first run tests, and will only deploy to Vercel if all tests have passed.

`deploy-preview` will run on each commit, and create a preview deployment on Vercel
`deploy-prod` will run only on merge/push to the `vercel-release` branch, and will create a production deployment on Vercel

Note: The building step is done on Vercel to save Github Action's usage quota